### PR TITLE
feat(hypr): interactive screenshot selection and focused monitor capture

### DIFF
--- a/dot-config/hypr/modules/keybindings.conf
+++ b/dot-config/hypr/modules/keybindings.conf
@@ -39,10 +39,8 @@ bindin = Super, mouse:277, global, caelestia:launcherInterrupt
 bindin = Super, mouse_up, global, caelestia:launcherInterrupt
 bindin = Super, mouse_down, global, caelestia:launcherInterrupt
 bind = $mainMod, F, fullscreen
-bind = $mainMod, S, exec, grim -g "$(slurp)" - | swappy -f - # take a screenshot
-# Take a screenshot on the currently focused monitor screen
-# bind = $mainMod SHIFT, S, exec, grim -g "$(hyprctl monitors -j | jq -r '.[] | select(.focused) | "\(.x),\(.y) \(.width)x\(.height)"')" - | swappy -f -
-bind = $mainMod SHIFT, S, exec, caelestia screenshot
+bind = $mainMod, S, exec, ~/dotfiles/dot-config/programs/shell_scripts/screenshot-selection-copy.sh
+bind = $mainMod SHIFT, S, exec, ~/dotfiles/dot-config/programs/shell_scripts/screenshot-focused-monitor.sh
 bind = ALT, V, exec, cliphist list | wofi -dmenu | cliphist decode | wl-copy # open clipboard manager
 bind = ALT, C, exec, ~/dotfiles/dot-config/programs/shell_scripts/cliphist-remove-entry.sh
 bind = CTRL ALT, C, exec, ~/dotfiles/dot-config/programs/shell_scripts/get-cursor-pos.sh

--- a/dot-config/programs/shell_scripts/screenshot-focused-monitor.sh
+++ b/dot-config/programs/shell_scripts/screenshot-focused-monitor.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Screenshot focused monitor with notification, copy to clipboard, and open option
+
+SCREENSHOTS_DIR="$HOME/Pictures"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+SCREENSHOT_PATH="$SCREENSHOTS_DIR/Screenshot-$TIMESTAMP.png"
+
+# Get focused monitor geometry
+MONITOR_GEO=$(hyprctl monitors -j | jq -r '.[] | select(.focused) | "\(.x),\(.y) \(.width)x\(.height)"')
+
+if [[ -z "$MONITOR_GEO" ]]; then
+  notify-send -a "hyprland" "Failed to get focused monitor"
+  exit 1
+fi
+
+# Capture focused monitor
+grim -g "$MONITOR_GEO" "$SCREENSHOT_PATH"
+
+if [[ ! -f "$SCREENSHOT_PATH" ]]; then
+  notify-send -a "hyprland" "Failed to save screenshot"
+  exit 1
+fi
+
+# Copy to clipboard
+wl-copy < "$SCREENSHOT_PATH"
+
+# Show notification with open action
+ACTION=$(notify-send -a "hyprland" \
+  -i "$SCREENSHOT_PATH" \
+  -A "open=Open" \
+  "Screenshot saved" \
+  "$SCREENSHOT_PATH")
+
+# Handle open action
+if [[ "$ACTION" == "open" ]]; then
+  xdg-open "$SCREENSHOT_PATH" &
+fi

--- a/dot-config/programs/shell_scripts/screenshot-focused-monitor.sh
+++ b/dot-config/programs/shell_scripts/screenshot-focused-monitor.sh
@@ -31,7 +31,13 @@ ACTION=$(notify-send -a "hyprland" \
   "Screenshot saved" \
   "$SCREENSHOT_PATH")
 
-# Handle open action
+# Handle open action with fallback chain
 if [[ "$ACTION" == "open" ]]; then
-  xdg-open "$SCREENSHOT_PATH" &
+  if command -v nautilus &>/dev/null; then
+    nautilus -w "$(dirname "$SCREENSHOT_PATH")" &
+  elif command -v swappy &>/dev/null; then
+    swappy -f "$SCREENSHOT_PATH" &
+  else
+    xdg-open "$SCREENSHOT_PATH" &
+  fi
 fi

--- a/dot-config/programs/shell_scripts/screenshot-focused-monitor.sh
+++ b/dot-config/programs/shell_scripts/screenshot-focused-monitor.sh
@@ -34,7 +34,7 @@ ACTION=$(notify-send -a "hyprland" \
 # Handle open action with fallback chain
 if [[ "$ACTION" == "open" ]]; then
   if command -v nautilus &>/dev/null; then
-    nautilus -w "$(dirname "$SCREENSHOT_PATH")" &
+    nautilus -w "$SCREENSHOT_PATH" &
   elif command -v swappy &>/dev/null; then
     swappy -f "$SCREENSHOT_PATH" &
   else

--- a/dot-config/programs/shell_scripts/screenshot-selection-copy.sh
+++ b/dot-config/programs/shell_scripts/screenshot-selection-copy.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Interactive screenshot selection with hyprshot
+
+SCREENSHOTS_DIR="$HOME/Pictures"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+SCREENSHOT_PATH="$SCREENSHOTS_DIR/Screenshot-$TIMESTAMP.png"
+
+# Capture region with hyprshot using timestamped filename
+TEMP_NAME="Screenshot-$TIMESTAMP.png"
+hyprshot -m region --freeze -s -f "$TEMP_NAME" -o "$SCREENSHOTS_DIR" 2>/dev/null
+
+# Check if screenshot was taken
+if [[ ! -f "$SCREENSHOT_PATH" ]]; then
+  notify-send -a "hyprland" "Screenshot cancelled or failed"
+  exit 1
+fi
+
+# Copy to clipboard
+wl-copy < "$SCREENSHOT_PATH"
+
+# Show notification with Open action (consistent with focused monitor)
+ACTION=$(notify-send -a "hyprland" \
+  -i "$SCREENSHOT_PATH" \
+  -A "open=Open" \
+  "Screenshot saved" \
+  "$SCREENSHOT_PATH")
+
+# Handle open action
+if [[ "$ACTION" == "open" ]]; then
+  xdg-open "$SCREENSHOT_PATH" &
+fi

--- a/dot-config/programs/shell_scripts/screenshot-selection-copy.sh
+++ b/dot-config/programs/shell_scripts/screenshot-selection-copy.sh
@@ -25,7 +25,13 @@ ACTION=$(notify-send -a "hyprland" \
   "Screenshot saved" \
   "$SCREENSHOT_PATH")
 
-# Handle open action
+# Handle open action with fallback chain
 if [[ "$ACTION" == "open" ]]; then
-  xdg-open "$SCREENSHOT_PATH" &
+  if command -v nautilus &>/dev/null; then
+    nautilus -w "$(dirname "$SCREENSHOT_PATH")" &
+  elif command -v swappy &>/dev/null; then
+    swappy -f "$SCREENSHOT_PATH" &
+  else
+    xdg-open "$SCREENSHOT_PATH" &
+  fi
 fi

--- a/dot-config/programs/shell_scripts/screenshot-selection-copy.sh
+++ b/dot-config/programs/shell_scripts/screenshot-selection-copy.sh
@@ -28,7 +28,7 @@ ACTION=$(notify-send -a "hyprland" \
 # Handle open action with fallback chain
 if [[ "$ACTION" == "open" ]]; then
   if command -v nautilus &>/dev/null; then
-    nautilus -w "$(dirname "$SCREENSHOT_PATH")" &
+    nautilus -w "$SCREENSHOT_PATH" &
   elif command -v swappy &>/dev/null; then
     swappy -f "$SCREENSHOT_PATH" &
   else


### PR DESCRIPTION
## Summary
Add two new screenshot workflows to Hyprland with improved UX and clipboard integration.

## Changes
- **Super+S** — Interactive region selection with hyprshot
  - Freezes screen for precise selection
  - Saves timestamped screenshots to `~/Pictures/Screenshot-YYYYMMDD-HHMMSS.png`
  - Automatically copies to clipboard
  - Notification with screenshot preview and Open button
  
- **Super+Shift+S** — Focused monitor capture
  - Captures only the currently focused monitor
  - Copies to clipboard automatically
  - Consistent notification format with Super+S

- **Open action** — Intelligent fallback chain
  - Prioritizes Nautilus file manager (shows file selected in directory)
  - Falls back to Swappy image editor if Nautilus unavailable
  - Final fallback to system default app via xdg-open

Replaces previous implementation using `caelestia screenshot` with more granular control and better integration.

## Test plan
- [x] Super+S: Select region, verify screenshot saved with timestamp, copied to clipboard, and Open opens in Nautilus with file selected
- [x] Super+Shift+S: Verify captures focused monitor only (test with multiple displays), clipboard copy works, Open action works
- [x] Fallback chain: Test with/without Nautilus and Swappy installed
- [x] Notification displays correctly with screenshot preview on both keybinds

> [!NOTE]
> Generated with [Claude Code](https://claude.com/claude-code).